### PR TITLE
Changed instructions on how to reach personalizer configurations

### DIFF
--- a/samples/azurenotebook/Personalizer.ipynb
+++ b/samples/azurenotebook/Personalizer.ipynb
@@ -95,7 +95,7 @@
    "source": [
     "## Configure Personalizer resource\n",
     "\n",
-    "In the Azure portal, configure your [Personalizer resource](https://ms.portal.azure.com/#create/Microsoft.CognitiveServicesPersonalizer) with the **update model frequency** set to 15 seconds and a **reward wait time** of 15 seconds. These settings are found on the **[Settings](how-to-settings.md#configure-service-settings-in-the-azure-portal)** page. \n",
+    "In the Azure portal, configure your [Personalizer resource](https://ms.portal.azure.com/#create/Microsoft.CognitiveServicesPersonalizer) with the **update model frequency** set to 15 seconds and a **reward wait time** of 15 seconds. These settings are found in the in the Configurations tab, under the RESOURCE MANAGEMENT section. \n",
     "\n",
     "|Setting|Value|\n",
     "|--|--|\n",
@@ -774,7 +774,7 @@
     "\n",
     "`100-20=80`\n",
     "\n",
-    "This exploration setting is found in the Azure portal, for the Personalizer resource, on the **Settings** page. \n",
+    "This exploration setting is found in the Azure portal, for the Personalizer resource, in the Configurations tab, under the RESOURCE MANAGEMENT section \n",
     "\n",
     "In order to find a better learning policy, based on your data to the Rank API, run an [offline evaluation](how-to-offline-evaluation.md) in the portal for your Personalizer loop."
    ]
@@ -803,7 +803,7 @@
    "source": [
     "## Change update model frequency to 5 minutes\n",
     "\n",
-    "1. In the Azure portal, still on the Personalizer resource, select the **Settings** page. \n",
+    "1. In the Azure portal, still on the Personalizer resource, selec the Configurations tab, under the RESOURCE MANAGEMENT section. \n",
     "1. Change the **model update frequency** and **reward wait time** to 5 minutes and select **Save**.\n",
     "\n",
     "Learn more about the [reward wait time](https://docs.microsoft.com/en-us/azure/cognitive-services/personalizer/concept-rewards#reward-wait-time) and [model update frequency](https://docs.microsoft.com/en-us/azure/cognitive-services/personalizer/how-to-settings#model-update-frequency)."


### PR DESCRIPTION
Changing the reward wat time, exploration and update frequency settings are found on the configuration page on Azure portal. The tutorial had them listed under settings and there is no setting tab in the portal, so I updated the instructions.

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->